### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup_kwargs = {
         'jsonmodel',
         'labpack',
         'tabulate>=0.7.7',
-        'ruamel.yaml>=0.14.12'
+        'ruamel.yaml>=0.14.12,<0.15'
     ],
     'classifiers': [
         # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Thank you for using ruamel.yaml. 

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your users could see. 
Therefore please release a version of your package with this change, so that it will not 
automatically take the latest ruamel.yaml release.